### PR TITLE
French locale fixes

### DIFF
--- a/usr/share/openmediavault/locale/fr/openmediavault-webdav.po
+++ b/usr/share/openmediavault/locale/fr/openmediavault-webdav.po
@@ -31,7 +31,7 @@ msgid "Shared Folder"
 msgstr "Dossier partagé"
 
 msgid "This share will have ownership changed to www-data:users."
-msgstr "Ce partage verra son propriétaire changé à www-data:users."
+msgstr "Ce partage verra son propriétaire changé en www-data:users."
 
 msgid "WebDAV"
 msgstr "WebDAV"

--- a/usr/share/openmediavault/locale/fr/openmediavault-webdav.po
+++ b/usr/share/openmediavault/locale/fr/openmediavault-webdav.po
@@ -34,4 +34,4 @@ msgid "This share will have ownership changed to www-data:users."
 msgstr "Ce partage verra son propriétaire changé à www-data:users."
 
 msgid "WebDAV"
-msgstr "XebDAV"
+msgstr "WebDAV"

--- a/usr/share/openmediavault/locale/fr_FR/openmediavault-webdav.po
+++ b/usr/share/openmediavault/locale/fr_FR/openmediavault-webdav.po
@@ -31,7 +31,7 @@ msgid "Shared Folder"
 msgstr "Dossier partagé"
 
 msgid "This share will have ownership changed to www-data:users."
-msgstr "Ce partage verra son propriétaire changé à www-data:users."
+msgstr "Ce partage verra son propriétaire changé en www-data:users."
 
 msgid "WebDAV"
 msgstr "WebDAV"

--- a/usr/share/openmediavault/locale/fr_FR/openmediavault-webdav.po
+++ b/usr/share/openmediavault/locale/fr_FR/openmediavault-webdav.po
@@ -34,4 +34,4 @@ msgid "This share will have ownership changed to www-data:users."
 msgstr "Ce partage verra son propriétaire changé à www-data:users."
 
 msgid "WebDAV"
-msgstr "XebDAV"
+msgstr "WebDAV"


### PR DESCRIPTION
Here are 2 trivial fixes.
One is just a typo (XebDAV -> WebDAV).
And the other is a grammatical fix.
