### PR TITLE
Override 404 error page

### DIFF
--- a/srv/salt/omv/deploy/webdav/default.sls
+++ b/srv/salt/omv/deploy/webdav/default.sls
@@ -40,6 +40,7 @@ configure_webdav:
             auth_pam_service_name "openmediavault-webdav";
             {% endif -%}
             autoindex on;
+            error_page 404 /_404;
         }
     - user: root
     - group: root


### PR DESCRIPTION
This PR fixes #21.

I have tested the patch by manually modifying the `/etc/nginx/openmediavault-webgui.d/openmediavault-webdav.conf` file.

Before modifying:

```
$ curl -u user:pass -v http://host/webdav/nonexistent
...
< HTTP/1.1 302 Moved Temporarily
...
```

After modifying:

```
$ curl -u user:pass -v http://host/webdav/nonexistent
...
< HTTP/1.1 404 Not Found
...
```