### PR TITLE
Support directory operations (fixes #23)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Architecture: all
 Depends: openmediavault (>= 7),
          libnginx-mod-http-auth-pam,
          libnginx-mod-http-dav-ext,
+         libnginx-mod-http-headers-more-filter,
          ${misc:Depends}
 Description: OpenMediaVault WebDAV plugin.
  Web interface to enable WebDAV and select a share for files.


### PR DESCRIPTION
This configuration works on my end. Please check it.

Note that I changed `rewrite ^(.*[^/])$ $1/ break;` to `rewrite ^(.*[^/])$ $1/;` (removed "break") to avoid the below error. Not sure why this change will fix the error and whether it will bring other problems.

```
2024/03/24 22:55:09 [alert] 3457036#3457036: *22210 "alias" cannot be used in location "/webdav" where URI was rewritten, client: 127.0.0.1, server: openmediavault-webgui, request: "MKCOL ... HTTP/1.1", host: "..."
```