### PR TITLE
Increase /webdav prefix priority

### DIFF
--- a/srv/salt/omv/deploy/webdav/default.sls
+++ b/srv/salt/omv/deploy/webdav/default.sls
@@ -38,7 +38,7 @@ configure_webdav:
   file.managed:
     - name: "{{ confFile }}"
     - contents: |
-        location /webdav {
+        location ^~ /webdav {
             alias {{ sfpath }};
             dav_methods PUT DELETE MKCOL COPY MOVE;
             dav_ext_methods PROPFIND OPTIONS LOCK UNLOCK;


### PR DESCRIPTION
This PR resolves the issue raised on the forums where ["no json files can be copied to the web-dav share."](https://forum.openmediavault.org/index.php?thread/54748-json-files-cannot-be-copied-to-webdav/&postID=406469#post406469)

The openmediavault webgui [uses some locations with regex prefixes (`\.json$`, `\.php$`) that nginx will prioritize first](https://github.com/openmediavault/openmediavault/blob/9e7cdb88bb1b5606be1074adbe73ac79c55966c1/deb/openmediavault/srv/salt/omv/deploy/nginx/files/site-webgui.j2#L33-L44) over the `/webdav` prefix string location. Since `.json` and `.php` files aren't being routed to the `/webdav` location context, requests are resolved with the default root directive instead of the shared folder path.

This PR adds the `^~` modifier for the webdav location context, which skips regex matching checks and just uses the longest matching prefix string. This means that the `/webdav` location context is prioritized over the `\.json$` and `\.php$` location contexts, so the final request is correctly routed.

I've tested the path modification on my local environment. This is a little different than the proposed fix on the forum, as I omitted the check to add no caching headers for `json` files. Presumably none of the json files in the `/webdav` path are system generated so there isn't a need to constantly ensure they're up-to-date. Users can use the settings to add caching behavior rules instead.